### PR TITLE
feat: set bouncycastle deps as a compile dependency explicitly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,11 @@
         </exclusions>
       </dependency>
       <dependency>
+        <groupId>org.bouncycastle</groupId>
+        <artifactId>bcprov-jdk15on</artifactId>
+        <scope>compile</scope>
+      </dependency>
+      <dependency>
         <groupId>org.keycloak</groupId>
         <artifactId>keycloak-admin-client</artifactId>
         <version>${version.keycloak}</version>


### PR DESCRIPTION
(cherry picked from commit b44f6b788e2be3ee745e278b09851a430bee4c8f)